### PR TITLE
server clean命令兼容fis3

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ exports.register = function(commander) {
         var s_reg;
         globArr.forEach(function(g) {
             if (g.length > 0) {
-                s_reg = fis.util.glob(g).toString();
+                s_reg = fis.util.glob(g, undefined, {nocase: true}).toString();
                 //replace
                 // '/^' => ''
                 // '$/i' => ''
@@ -39,7 +39,7 @@ exports.register = function(commander) {
         });
         prefix = prefix || '';
         if (prefix) {
-            s_reg = fis.util.glob(prefix).toString();
+            s_reg = fis.util.glob(prefix, undefined, {nocase: true}).toString();
             // '/^' => '', '%/i' => ''
             prefix = s_reg.substr(2, s_reg.length - 5);
         }


### PR DESCRIPTION
由于fis3与fis2中的 fis.util.glob 方法不同，这里需要做个向上兼容，否则由于 substr 的字符串多截取了一个 `)` 导致 server clean 命令报错